### PR TITLE
Changing style properties now affects all existing text by default

### DIFF
--- a/src/StyledTextLayout.cpp
+++ b/src/StyledTextLayout.cpp
@@ -294,19 +294,19 @@ void StyledTextLayout::clearText() {
 
 
 void StyledTextLayout::setText(const wstring& text) { clearText(); appendText(text); }
-void StyledTextLayout::setText(const wstring& text, const string styleName) { clearText(); appendText(text, styleName); }
-void StyledTextLayout::setText(const wstring& text, const Style& style) { clearText(); appendText(text, style); }
+void StyledTextLayout::setText(const wstring& text, const string styleName) { clearText(); appendText(text, styleName, true); }
+void StyledTextLayout::setText(const wstring& text, const Style& style) { clearText(); appendText(text, style, true); }
 
 void StyledTextLayout::appendText(const wstring& text) {
 	appendSegments(StyledTextParser::getInstance()->parse(text, mCurrentStyle, mParseOptions));
 }
-void StyledTextLayout::appendText(const wstring& text, const string& styleName) {
+void StyledTextLayout::appendText(const wstring& text, const string& styleName, bool saveAsCurrentStyle) {
 	Style style = StyleManager::getInstance()->getStyle(styleName);
-	setCurrentStyle(style);
+	if (saveAsCurrentStyle) setCurrentStyle(style);
 	appendSegments(StyledTextParser::getInstance()->parse(text, style, mParseOptions));
 }
-void StyledTextLayout::appendText(const wstring& text, const Style& style) {
-	setCurrentStyle(style);
+void StyledTextLayout::appendText(const wstring& text, const Style& style, bool saveAsCurrentStyle) {
+	if (saveAsCurrentStyle) setCurrentStyle(style);
 	appendSegments(StyledTextParser::getInstance()->parse(text, style, mParseOptions));
 }
 
@@ -317,13 +317,13 @@ void StyledTextLayout::setPlainText(const wstring& text, const Style& style) { c
 void StyledTextLayout::appendPlainText(const wstring& text) {
 	appendSegment(StyledText(mCurrentStyle, text));
 }
-void StyledTextLayout::appendPlainText(const wstring& text, const string& styleName) {
+void StyledTextLayout::appendPlainText(const wstring& text, const string& styleName, bool saveAsCurrentStyle) {
 	Style style = StyleManager::getInstance()->getStyle(styleName);
-	setCurrentStyle(style);
+	if (saveAsCurrentStyle) setCurrentStyle(style);
 	appendSegment(StyledText(style, text));
 }
-void StyledTextLayout::appendPlainText(const wstring& text, const Style& style) {
-	setCurrentStyle(style);
+void StyledTextLayout::appendPlainText(const wstring& text, const Style& style, bool saveAsCurrentStyle) {
+	if (saveAsCurrentStyle) setCurrentStyle(style);
 	appendSegment(StyledText(style, text));
 }
 
@@ -334,16 +334,16 @@ void StyledTextLayout::setText(const string& text, const string styleName) { set
 void StyledTextLayout::setText(const string& text, const Style& style) { setText(wideString(text), style); }
 
 void StyledTextLayout::appendText(const string& text) { appendText(wideString(text)); }
-void StyledTextLayout::appendText(const string& text, const string& styleName) { appendText(wideString(text), styleName); }
-void StyledTextLayout::appendText(const string& text, const Style& style) { appendText(wideString(text), style); }
+void StyledTextLayout::appendText(const string& text, const string& styleName, bool saveAsCurrentStyle) { appendText(wideString(text), styleName, saveAsCurrentStyle); }
+void StyledTextLayout::appendText(const string& text, const Style& style, bool saveAsCurrentStyle) { appendText(wideString(text), style, saveAsCurrentStyle); }
 
 void StyledTextLayout::setPlainText(const string& text) { setPlainText(wideString(text)); }
 void StyledTextLayout::setPlainText(const string& text, const string styleName) { setPlainText(wideString(text), styleName); }
 void StyledTextLayout::setPlainText(const string& text, const Style& style) { setPlainText(wideString(text), style); }
 
 void StyledTextLayout::appendPlainText(const string& text) { appendPlainText(wideString(text)); }
-void StyledTextLayout::appendPlainText(const string& text, const string& styleName) { appendPlainText(wideString(text), styleName); }
-void StyledTextLayout::appendPlainText(const string& text, const Style& style) { appendPlainText(wideString(text), style); }
+void StyledTextLayout::appendPlainText(const string& text, const string& styleName, bool saveAsCurrentStyle) { appendPlainText(wideString(text), styleName, saveAsCurrentStyle); }
+void StyledTextLayout::appendPlainText(const string& text, const Style& style, bool saveAsCurrentStyle) { appendPlainText(wideString(text), style, saveAsCurrentStyle); }
 
 
 //==================================================

--- a/src/StyledTextLayout.h
+++ b/src/StyledTextLayout.h
@@ -88,9 +88,9 @@ public:
 	//! Appends text to any existing text. More efficient than resetting all text if you just want to add to existing text. Parses supported style tags.
 	void appendText(const std::string& text);
 	//! Appends text to any existing text and and sets the current style by loading it from the StyleManager. Parses supported style tags.
-	void appendText(const std::string& text, const std::string& styleName);
+	void appendText(const std::string& text, const std::string& styleName, bool saveAsCurrentStyle = false);
 	//! Appends text to any existing text and and sets the current style. Parses supported style tags.
-	void appendText(const std::string& text, const Style& style);
+	void appendText(const std::string& text, const Style& style, bool saveAsCurrentStyle = false);
 
 	//! Replaces the current text with plain text and keeps the current style. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
 	void setPlainText(const std::string& text);
@@ -102,9 +102,9 @@ public:
 	//! Appends text to any existing text. More efficient than resetting all text if you just want to add to existing text. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
 	void appendPlainText(const std::string& text);
 	//! Appends text to any existing text and and sets the current style by loading it from the StyleManager. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
-	void appendPlainText(const std::string& text, const std::string& styleName);
+	void appendPlainText(const std::string& text, const std::string& styleName, bool saveAsCurrentStyle = false);
 	//! Appends text to any existing text and and sets the current style. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
-	void appendPlainText(const std::string& text, const Style& style);
+	void appendPlainText(const std::string& text, const Style& style, bool saveAsCurrentStyle = false);
 
 
 	//! Replaces the current text and keeps the current style. Parses supported style tags.
@@ -117,9 +117,9 @@ public:
 	//! Appends text to any existing text. More efficient than resetting all text if you just want to add to existing text. Parses supported style tags.
 	void appendText(const std::wstring& text);
 	//! Appends text to any existing text and and sets the current style by loading it from the StyleManager. Parses supported style tags.
-	void appendText(const std::wstring& text, const std::string& styleName);
+	void appendText(const std::wstring& text, const std::string& styleName, bool saveAsCurrentStyle = false);
 	//! Appends text to any existing text and and sets the current style. Parses supported style tags.
-	void appendText(const std::wstring& text, const Style& style);
+	void appendText(const std::wstring& text, const Style& style, bool saveAsCurrentStyle = false);
 
 	//! Replaces the current text with plain text. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
 	void setPlainText(const std::wstring& text);
@@ -131,9 +131,9 @@ public:
 	//! Appends text to any existing text. More efficient than resetting all text if you just want to add to existing text. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
 	void appendPlainText(const std::wstring& text);
 	//! Appends text to any existing text and and sets the current style by loading it from the StyleManager. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
-	void appendPlainText(const std::wstring& text, const std::string& styleName);
+	void appendPlainText(const std::wstring& text, const std::string& styleName, bool saveAsCurrentStyle = false);
 	//! Appends text to any existing text and and sets the current style. Text will not be parsed for style tags, making this method slightly more efficient than its text counterpart.
-	void appendPlainText(const std::wstring& text, const Style& style);
+	void appendPlainText(const std::wstring& text, const Style& style, bool saveAsCurrentStyle = false);
 
 
 
@@ -172,7 +172,7 @@ public:
 	void setSizeTrimmingEnabled(const bool value);
 
 
-	//! Apples padding to text. Positive padding adds space towards the inside, negative padding towards the outside. Works similar to css box-sizing: border-box.
+	//! Applies padding to text. Positive padding adds space towards the inside, negative padding towards the outside. Works similar to css box-sizing: border-box.
 	void setPadding(const float top, const float right, const float bottom, const float left);
 	void setPadding(const float vertical, const float horizontal);
 	void setPaddingTop(const float padding);


### PR DESCRIPTION
Changes some of the default values for setters so that using them is more intuitive for end users. We're essentially hiding the state-machine nature of `StyledTextLayout`. It's still more efficient to understand that appending text and keeping existing styles for previous text is more efficient, but there aren't a lot of scenarios  where this will be one manually. So changing styles via `setColor()`, `setFont()`, etc. now changes the color/font/etc. for all existing text, not just text that gets appended from here.

Addresses https://github.com/bluecadet/Cinder-BluecadetViews/issues/73