### PR TITLE
Feature/cinder v0.9.3 updates

### DIFF
--- a/src/bluecadet/text/StyledTextParser.cpp
+++ b/src/bluecadet/text/StyledTextParser.cpp
@@ -142,6 +142,7 @@ std::vector<StyledText> StyledTextParser::parse(const StringType& str, Style bas
 
 		// Does TRIM_WHITESPACE trim leading, trailing, or all white space? - KZ 
 		// Added utility function to trim leading and trailing whitespace
+		// TODO: Test trim
 		const StringType& text = options & TRIM_WHITESPACE ? text::trim(str) : str;
 
 		vector<StringType> tokens = splitStringIntoTokens(L"<root>" + text + L"</root>");

--- a/src/bluecadet/text/StyledTextParser.cpp
+++ b/src/bluecadet/text/StyledTextParser.cpp
@@ -140,14 +140,17 @@ std::vector<StyledText> StyledTextParser::parse(const StringType& str, Style bas
 		std::stack<Style> styles;
 		styles.push(baseStyle);
 
-		const StringType& text = options & TRIM_WHITESPACE ? boost::trim_copy(str) : str;
+		// Does TRIM_WHITESPACE trim leading, trailing, or all white space? - KZ 
+		// Added utility function to trim leading and trailing whitespace
+		const StringType& text = options & TRIM_WHITESPACE ? text::trim(str) : str;
 
 		vector<StringType> tokens = splitStringIntoTokens(L"<root>" + text + L"</root>");
 
 		for (auto& token : tokens) {
 			// Lowercase tag for consistent tag checks
-			const auto tag = boost::to_lower_copy(token);
-
+			std::transform(token.begin(), token.end(), token.begin(), ::tolower);
+			auto tag = token;
+			
 			// If has macthing custom parser, use it to parse token
 			if (customTokenParsers != nullptr) {
 				const auto iter = customTokenParsers->find(tag);

--- a/src/bluecadet/text/StyledTextParser.cpp
+++ b/src/bluecadet/text/StyledTextParser.cpp
@@ -149,7 +149,7 @@ std::vector<StyledText> StyledTextParser::parse(const StringType& str, Style bas
 		for (auto& token : tokens) {
 			// Lowercase tag for consistent tag checks
 			std::transform(token.begin(), token.end(), token.begin(), ::tolower);
-			auto tag = token;
+			const auto tag = token;
 			
 			// If has macthing custom parser, use it to parse token
 			if (customTokenParsers != nullptr) {

--- a/src/bluecadet/text/Text.h
+++ b/src/bluecadet/text/Text.h
@@ -262,44 +262,38 @@ inline StringType trim(StringType& str) {
 	return str;
 }
 
-
-// KZ - Question, this seems to have a boost reference in it but I assume since it doesn't have any calls to it it is not causing 
-// any compile issues?
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
 template <typename StringType, typename ContainerType>
 inline void tokenize(const StringType & str, ContainerType & tokenContainer, const StringType & delimiters) {
 	typedef typename StringType::value_type CharType;
-	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
-	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
-	tokenizer tok{str, sep};
-	for (const auto & t : tok) {
-		tokenContainer.push_back(t);
+
+	std::basic_stringstream<CharType> stringStream(str);
+	StringType line;
+
+	while (std::getline(stringStream, line))
+	{
+		std::size_t prev = 0, pos;
+		while ((pos = line.find_first_of(delimiters, prev)) != std::string::npos)
+		{
+			if (pos > prev) {
+				// push substring between last delimiter and this one
+				tokenContainer.push_back(line.substr(prev, pos - prev));
+				// push delimiter
+				tokenContainer.push_back(line.substr(pos, 1));
+			}
+			prev = pos + 1;
+		}
+		if (prev < line.length())
+			tokenContainer.push_back(line.substr(prev, std::string::npos));
 	}
+
 }
 
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
 template <typename StringType>
 inline std::list<StringType> tokenize(const StringType & str, const StringType & delimiters) {
 	std::list<StringType> tokenContainer;
-	//typedef typename StringType::value_type CharType;
-	//typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
-	//boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
-	//tokenizer tok{str, sep};
-
-	// stringstream class check1
-	//string s = str.c_str();
-	//std::stringstream strStream(str);
-
-	//// Temp string to hold token
-	//string tok;
-
-	//while (getline(strStream, tok, delimiters)) {
-	//	// Push token into container
-	//	tokenContainer.push_back(tok);
-	//}
-	// 
-	// KZ -- Look at tokenizing with  StringType
-
+	tokenize(str, tokenContainer, delimiters);
 	return tokenContainer;
 }
 

--- a/src/bluecadet/text/Text.h
+++ b/src/bluecadet/text/Text.h
@@ -15,8 +15,8 @@
 #include <cwctype>
 
 #include <iostream>
-#include <string>
 #include <algorithm>
+
 /* Commented out in cinder 0.9.3 upgrades */
 //#include <boost/algorithm/string.hpp>
 //#include <boost/tokenizer.hpp>
@@ -234,31 +234,34 @@ inline std::string colorToHexStr(const ci::ColorA & color, const std::string & p
 //
 //! Trim leading and trailing white space
 template <typename StringType>
-inline StringType trim(StringType& str) {
+inline StringType trim(const StringType& str) {
 	// Trim left
-	std::string WHITESPACE = " \n\r\t\f\v";
-	StringType test;
-	size_t start = test.find_first_not_of(WHITESPACE);
-	str = (start == std::string::npos) ? str : str.substr(start);
+	//const std::string WHITESPACE = " \n\r\t\f\v";
 
-	// Trim right
-	size_t end = test.find_last_not_of(WHITESPACE);
-	str = (end == std::string::npos) ? str : str.substr(0, end + 1);
+	//size_t start = str.c_str().find_first_not_of(WHITESPACE);
+	//(start == std::string::npos) ? str : str.substr(start);
+
+	//// Trim right
+	//size_t end = str.find_last_not_of(WHITESPACE);
+	//(end == std::string::npos) ? str : str.substr(0, end + 1);
+
+
+
 	// KZ -- Look at trim StringType
 	return str;
 }
 
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
-template <typename StringType, typename ContainerType>
-inline void tokenize(const StringType & str, ContainerType & tokenContainer, const StringType & delimiters) {
-	typedef typename StringType::value_type CharType;
-	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
-	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
-	tokenizer tok{str, sep};
-	for (const auto & t : tok) {
-		tokenContainer.push_back(t);
-	}
-}
+//template <typename StringType, typename ContainerType>
+//inline void tokenize(const StringType & str, ContainerType & tokenContainer, const StringType & delimiters) {
+//	typedef typename StringType::value_type CharType;
+//	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
+//	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
+//	tokenizer tok{str, sep};
+//	for (const auto & t : tok) {
+//		tokenContainer.push_back(t);
+//	}
+//}
 
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
 template <typename StringType>
@@ -270,7 +273,8 @@ inline std::list<StringType> tokenize(const StringType & str, const StringType &
 	//tokenizer tok{str, sep};
 
 	// stringstream class check1
-	//stringstream strStream(str);
+	//string s = str.c_str();
+	//std::stringstream strStream(str);
 
 	//// Temp string to hold token
 	//string tok;
@@ -283,6 +287,10 @@ inline std::list<StringType> tokenize(const StringType & str, const StringType &
 	// KZ -- Look at tokenizing with  StringType
 
 	return tokenContainer;
+}
+
+template <typename StringType>
+inline const auto foo(const StringType& s, char delimiter) {
 }
 
 //! Joins a list of strings with a join character.
@@ -316,6 +324,7 @@ template <typename StringType> inline const auto split(const StringType & s, cha
 
 //! Transforms text case. Returns a copy of the original text.
 template <typename StringType> inline StringType transform(const StringType & text, const TextTransform transform) {
+	StringType result(text);
 	switch (transform) {
 		case TextTransform::None:
 			return text;
@@ -325,10 +334,10 @@ template <typename StringType> inline StringType transform(const StringType & te
 			case TextTransform::Lowercase: run->append(boost::locale::to_lower(token)); break;
 			case TextTransform::Capitalize: run->append(boost::locale::to_title(token)); break;*/
 		case TextTransform::Uppercase: 
-			std::transform(text.begin(), text.end(), text.begin(), ::toupper);
-			return text;
-		case TextTransform::Lowercase: 
-			std::transform(text.begin(), text.end(), text.begin(), ::tolower);
+			std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+			return result;
+		case TextTransform::Lowercase:
+			std::transform(result.begin(), result.end(), result.begin(), ::tolower);
 			return text;
 		case TextTransform::Capitalize: return capitalize(text);
 		default: return text;

--- a/src/bluecadet/text/Text.h
+++ b/src/bluecadet/text/Text.h
@@ -234,34 +234,48 @@ inline std::string colorToHexStr(const ci::ColorA & color, const std::string & p
 //
 //! Trim leading and trailing white space
 template <typename StringType>
-inline StringType trim(const StringType& str) {
+inline StringType trim(StringType& str) {
 	// Trim left
 	//const std::string WHITESPACE = " \n\r\t\f\v";
 
-	//size_t start = str.c_str().find_first_not_of(WHITESPACE);
+	//size_t start = str.find_first_not_of(WHITESPACE);
 	//(start == std::string::npos) ? str : str.substr(start);
 
 	//// Trim right
 	//size_t end = str.find_last_not_of(WHITESPACE);
 	//(end == std::string::npos) ? str : str.substr(0, end + 1);
+	// TODO: Test trim
+	auto start = str.begin();
+	while (start != str.end() && std::isspace(*start)) {
+		start++;
+	}
 
+	auto end = str.end();
+	do {
+		end--;
+	} while (std::distance(start, end) > 0 && std::isspace(*end));
+
+	return StringType(start, end + 1);
 
 
 	// KZ -- Look at trim StringType
 	return str;
 }
 
+
+// KZ - Question, this seems to have a boost reference in it but I assume since it doesn't have any calls to it it is not causing 
+// any compile issues?
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
-//template <typename StringType, typename ContainerType>
-//inline void tokenize(const StringType & str, ContainerType & tokenContainer, const StringType & delimiters) {
-//	typedef typename StringType::value_type CharType;
-//	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
-//	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
-//	tokenizer tok{str, sep};
-//	for (const auto & t : tok) {
-//		tokenContainer.push_back(t);
-//	}
-//}
+template <typename StringType, typename ContainerType>
+inline void tokenize(const StringType & str, ContainerType & tokenContainer, const StringType & delimiters) {
+	typedef typename StringType::value_type CharType;
+	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
+	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
+	tokenizer tok{str, sep};
+	for (const auto & t : tok) {
+		tokenContainer.push_back(t);
+	}
+}
 
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
 template <typename StringType>
@@ -289,9 +303,6 @@ inline std::list<StringType> tokenize(const StringType & str, const StringType &
 	return tokenContainer;
 }
 
-template <typename StringType>
-inline const auto foo(const StringType& s, char delimiter) {
-}
 
 //! Joins a list of strings with a join character.
 template <typename StringType, typename ContainerType>

--- a/src/bluecadet/text/Text.h
+++ b/src/bluecadet/text/Text.h
@@ -10,8 +10,19 @@
 #include <string>
 #include <sstream> 
 
-#include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
+/* Added in cinder 0.9.3 upgrades */
+#include <clocale>
+#include <cwctype>
+
+#include <iostream>
+#include <string>
+#include <algorithm>
+/* Commented out in cinder 0.9.3 upgrades */
+//#include <boost/algorithm/string.hpp>
+//#include <boost/tokenizer.hpp>
+
+/* EOF file/header comments additions */
+
 
 namespace bluecadet {
 namespace text {
@@ -221,6 +232,21 @@ inline std::string colorToHexStr(const ci::ColorA & color, const std::string & p
 //==================================================
 // Text helpers
 //
+//! Trim leading and trailing white space
+template <typename StringType>
+inline StringType trim(StringType& str) {
+	// Trim left
+	std::string WHITESPACE = " \n\r\t\f\v";
+	StringType test;
+	size_t start = test.find_first_not_of(WHITESPACE);
+	str = (start == std::string::npos) ? str : str.substr(start);
+
+	// Trim right
+	size_t end = test.find_last_not_of(WHITESPACE);
+	str = (end == std::string::npos) ? str : str.substr(0, end + 1);
+	// KZ -- Look at trim StringType
+	return str;
+}
 
 //! Splits a string into tokens based on delimiters. All delimiters are returned as tokens themselves.
 template <typename StringType, typename ContainerType>
@@ -238,13 +264,24 @@ inline void tokenize(const StringType & str, ContainerType & tokenContainer, con
 template <typename StringType>
 inline std::list<StringType> tokenize(const StringType & str, const StringType & delimiters) {
 	std::list<StringType> tokenContainer;
-	typedef typename StringType::value_type CharType;
-	typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
-	boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
-	tokenizer tok{str, sep};
-	for (const auto & t : tok) {
-		tokenContainer.push_back(t);
-	}
+	//typedef typename StringType::value_type CharType;
+	//typedef boost::tokenizer<boost::char_separator<wchar_t>, typename StringType::const_iterator, StringType> tokenizer;
+	//boost::char_separator<wchar_t> sep{StringType().c_str(), delimiters.c_str()};
+	//tokenizer tok{str, sep};
+
+	// stringstream class check1
+	//stringstream strStream(str);
+
+	//// Temp string to hold token
+	//string tok;
+
+	//while (getline(strStream, tok, delimiters)) {
+	//	// Push token into container
+	//	tokenContainer.push_back(tok);
+	//}
+	// 
+	// KZ -- Look at tokenizing with  StringType
+
 	return tokenContainer;
 }
 
@@ -287,8 +324,12 @@ template <typename StringType> inline StringType transform(const StringType & te
 			/*case TextTransform::Uppercase: run->append(boost::locale::to_upper(token)); break;
 			case TextTransform::Lowercase: run->append(boost::locale::to_lower(token)); break;
 			case TextTransform::Capitalize: run->append(boost::locale::to_title(token)); break;*/
-		case TextTransform::Uppercase: return boost::algorithm::to_upper_copy(text);
-		case TextTransform::Lowercase: return boost::algorithm::to_lower_copy(text);
+		case TextTransform::Uppercase: 
+			std::transform(text.begin(), text.end(), text.begin(), ::toupper);
+			return text;
+		case TextTransform::Lowercase: 
+			std::transform(text.begin(), text.end(), text.begin(), ::tolower);
+			return text;
 		case TextTransform::Capitalize: return capitalize(text);
 		default: return text;
 	}


### PR DESCRIPTION
**DO NOT MERGE IN -- PR MADE FOR PROGRESS UPDATE**

This is the first investigation to upgrading our blocks to support Cinder v0.9.3. My goal was to get the Cinder-BluecadetText blocks to compile because of the Cinder-BluecadetViews dependencies on this block. 

Mainly need to remove boost for a lot of string/text operations and change deprecated functions. 

- Added utility _text:trim()_ function to replace boost trim **needs to be tested**
- std::transform to replace toLower and toUpper functions **needs to be tested**
- Commeneted out _tokenize_ function. Unable to get replacement code to compile (possible due to templatized typename to support both string and wstring).  _tokenize_ is important and the base of a lot of our text functionality so that needs to get implemented then tested. 
